### PR TITLE
Add in-memory cache for supported languages

### DIFF
--- a/translate/main.go
+++ b/translate/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"slices"
 	"strings"
+	"sync"
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
@@ -308,10 +309,25 @@ func cacheTranslatedText(ctx context.Context, dynamoClient DynamoDBClient, item 
 	return err
 }
 
+// This is an in-memory cache of the supported languages to persist them until
+// the lambda env is destroyed
+var supportedLanguageCache = sync.Map{}
+
 func doesTargetLanguageExist(ctx context.Context, translateClient TranslateClient, targetLanguage string) (bool, error) {
+	// Check cache
+	if _, ok := supportedLanguageCache.Load(targetLanguage); ok {
+		return true, nil
+	}
+
+	// Cache miss
 	languages, err := getSupportedLanguages(ctx, translateClient)
 	if err != nil {
 		return false, err
+	}
+
+	// Update cache
+	for _, language := range languages {
+		supportedLanguageCache.Store(language, true)
 	}
 
 	return slices.Contains(languages, targetLanguage), nil

--- a/translate/main_test.go
+++ b/translate/main_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"slices"
+	"sync"
 	"testing"
 
 	"github.com/aws/aws-lambda-go/events"
@@ -323,6 +324,11 @@ func TestDoesTargetLanguageExist(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Cleanup(func() {
+				// Reset the cache for testing
+				supportedLanguageCache = sync.Map{}
+			})
+
 			mockClient := &MockTranslateClient{
 				ListLanguagesFunc: func(ctx context.Context, params *translate.ListLanguagesInput, optFns ...func(*translate.Options)) (*translate.ListLanguagesOutput, error) {
 					if tt.mockError != nil {


### PR DESCRIPTION
This pull request introduces an in-memory cache for supported languages in the `translate` package to improve performance by avoiding repeated calls to the translation service. The most important changes include adding a `sync.Map` for caching, updating the `doesTargetLanguageExist` function to utilize this cache, and ensuring the cache is reset during tests.

Caching implementation:

* [`translate/main.go`](diffhunk://#diff-f0eebfdf591225ad193f7e5fe40ea3b483e0ce53e1a8cd91a54b1fe41950b27cR12): Added `sync` to imports and introduced `supportedLanguageCache`, an in-memory cache using `sync.Map`, to store supported languages. Modified `doesTargetLanguageExist` to check this cache before calling the translation service. [[1]](diffhunk://#diff-f0eebfdf591225ad193f7e5fe40ea3b483e0ce53e1a8cd91a54b1fe41950b27cR12) [[2]](diffhunk://#diff-f0eebfdf591225ad193f7e5fe40ea3b483e0ce53e1a8cd91a54b1fe41950b27cR312-R332)

Testing updates:

* [`translate/main_test.go`](diffhunk://#diff-188f1de37d3fb67027f78e3060cd4f22e7a5723d707bc2595bbba2d27503a49aR8): Added `sync` to imports and included a cleanup step in `TestDoesTargetLanguageExist` to reset the cache after each test run. [[1]](diffhunk://#diff-188f1de37d3fb67027f78e3060cd4f22e7a5723d707bc2595bbba2d27503a49aR8) [[2]](diffhunk://#diff-188f1de37d3fb67027f78e3060cd4f22e7a5723d707bc2595bbba2d27503a49aR327-R331)