### PR TITLE
Remove unnecessary resolve_s3 parameter from deploy and package confi…

### DIFF
--- a/samconfig.toml
+++ b/samconfig.toml
@@ -15,7 +15,6 @@ lint = true
 [default.deploy.parameters]
 capabilities = "CAPABILITY_IAM"
 confirm_changeset = true
-resolve_s3 = true
 s3_prefix = "gotranslate"
 region = "us-east-2"
 disable_rollback = true
@@ -23,7 +22,6 @@ parameter_overrides = "Environment=\"dev\" Application=\"gotranslate\" Owner=\"M
 image_repositories = []
 
 [default.package.parameters]
-resolve_s3 = true
 
 [default.sync.parameters]
 watch = true


### PR DESCRIPTION
…gurations

This pull request includes a small change to the `samconfig.toml` file. The change removes the `resolve_s3` parameter from the `[default.deploy.parameters]` and `[default.package.parameters]` sections. 

* [`samconfig.toml`](diffhunk://#diff-eeb7eaf77ca8ad1dfaf438d0e504ca99dca36448af1078b3881b67fb019853c9L18-L26): Removed `resolve_s3` parameter from `[default.deploy.parameters]` and `[default.package.parameters]` sections.