### PR TITLE
Refactor translation handling to use a slice for results

### DIFF
--- a/translate/main_test.go
+++ b/translate/main_test.go
@@ -689,7 +689,7 @@ func TestHandle(t *testing.T) {
 			},
 			expectedResponse: events.APIGatewayProxyResponse{
 				StatusCode: http.StatusInternalServerError,
-				Body:       "Error checking cache",
+				Body:       "Error during translation",
 			},
 			wantErr: false,
 		},


### PR DESCRIPTION
This pull request refactors the translation handling logic in `translate/main.go` to simplify the code and improve performance. The key changes include replacing the `indexedResult` struct and a results channel with a slice for managing translated sentences, adding logging for error handling, and updating test cases to reflect the changes.

### Refactoring for Simplification and Performance:

* Removed the `indexedResult` struct and the `results` channel, replacing them with a `translatedSentences` slice to directly store translated sentences by index. This simplifies the code and avoids the overhead of managing a channel. (`translate/main.go`, [[1]](diffhunk://#diff-f0eebfdf591225ad193f7e5fe40ea3b483e0ce53e1a8cd91a54b1fe41950b27cL81-L85) [[2]](diffhunk://#diff-f0eebfdf591225ad193f7e5fe40ea3b483e0ce53e1a8cd91a54b1fe41950b27cL158-R159) [[3]](diffhunk://#diff-f0eebfdf591225ad193f7e5fe40ea3b483e0ce53e1a8cd91a54b1fe41950b27cL176-R171) [[4]](diffhunk://#diff-f0eebfdf591225ad193f7e5fe40ea3b483e0ce53e1a8cd91a54b1fe41950b27cL198-L222)

### Error Handling Improvements:

* Added a `log.Printf` statement to log errors during the translation process for better debugging and visibility. (`translate/main.go`, [translate/main.goL198-L222](diffhunk://#diff-f0eebfdf591225ad193f7e5fe40ea3b483e0ce53e1a8cd91a54b1fe41950b27cL198-L222))

### Test Case Updates:

* Updated the test case in `translate/main_test.go` to match the new error message format ("Error during translation"). (`translate/main_test.go`, [translate/main_test.goL692-R692](diffhunk://#diff-188f1de37d3fb67027f78e3060cd4f22e7a5723d707bc2595bbba2d27503a49aL692-R692))

### Minor Changes:

* Added the `log` package to the imports to support the new logging functionality. (`translate/main.go`, [translate/main.goR8](diffhunk://#diff-f0eebfdf591225ad193f7e5fe40ea3b483e0ce53e1a8cd91a54b1fe41950b27cR8))