### PR TITLE
Add integration tests for translation API

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -31,6 +31,7 @@ env:
   # prod "sam package" and "sam deploy" commands.
   # PROD_IMAGE_REPOSITORY = '0123456789.dkr.ecr.region.amazonaws.com/repository-name'
   PROD_REGION: us-east-2
+  TESTING_API_KEY : ${{ secrets.TESTING_API_KEY }}
 
 jobs:
   test:
@@ -206,8 +207,40 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: |
-          # trigger the integration tests here
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+          cache: 'pip'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r pytest/requirements.txt
+      - name: Get Cloudformation Outputs
+        run: |
+          STACK_OUTPUT=$(aws cloudformation describe-stacks \
+            --stack-name ${TESTING_STACK_NAME} \
+            --region ${TESTING_REGION} \
+            --query "Stacks[0].Outputs" \
+            --output json)
+          API_URL=$(echo "$STACK_OUTPUT" | jq -r '.[] | select(.OutputKey=="TranslateAPI").OutputValue')
+          echo "API_URL=$API_URL" >> $GITHUB_ENV
+        env:
+          AWS_ACCESS_KEY_ID: ${{ env.PIPELINE_USER_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ env.PIPELINE_USER_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ env.TESTING_REGION }}
+      - name: Run integration tests
+        run: |
+          pytest --junitxml=junit/test-results.xml
+        env:
+          TESTING_API_KEY: ${{ env.TESTING_API_KEY }}
+          API_URL: ${{ env.API_URL }}
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        with:
+          name: pytest-results
+          path: junit/test-results.xml
+        if: ${{ always() }}
 
   deploy-prod:
     if: github.ref == 'refs/heads/main'

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,12 @@
+# Ignore AWS SAM build artifacts
 .aws-sam/*
+
+# Ignore Python bytecode files
+*.pyc
+# Ignore Python cache directories
+__pycache__/
+.pytest_cache/
+
+# Ignore virtual environment directories
+.venv/
+venv/

--- a/pytest/requirements.txt
+++ b/pytest/requirements.txt
@@ -1,0 +1,11 @@
+certifi==2025.1.31
+charset-normalizer==3.4.1
+exceptiongroup==1.2.2
+idna==3.10
+iniconfig==2.1.0
+packaging==24.2
+pluggy==1.5.0
+pytest==8.3.5
+requests==2.32.3
+tomli==2.2.1
+urllib3==2.4.0

--- a/pytest/test_integration.py
+++ b/pytest/test_integration.py
@@ -1,0 +1,87 @@
+import requests
+import os
+import pytest
+
+@pytest.fixture
+def api_key():
+    return os.getenv('API_KEY', '')
+
+
+@pytest.fixture
+def base_url():
+    return os.getenv('BASE_URL', 'http://127.0.0.1:3000')
+
+
+@pytest.fixture
+def headers(api_key):
+    return {
+        'X-Api-Key': api_key
+    }
+
+
+@pytest.fixture
+def translate_url(base_url):
+    return f'{base_url}/translate'
+
+
+def test_translate_content(translate_url, headers):
+    source_language = 'en'
+    target_language = 'es'
+    text = 'Hello, world!'
+
+    response = requests.post(
+        translate_url,
+        json={
+            'source_language': source_language,
+            'target_language': target_language,
+            'text': text
+        },
+        headers=headers
+    )
+
+    assert response.status_code == 200, f"Expected status code 200, got {response.status_code}"
+    response_data = response.json()
+    assert 'translated_text' in response_data, "Response does not contain 'translated_text'"
+    assert response_data['translated_text'] == '¡Hola, mundo!', "Translation did not match expected output"
+
+
+def test_translate_content_with_invalid_language(translate_url, headers):
+    source_language = 'xx'
+    target_language = 'es'
+    text = 'Hello, world!'
+
+    response = requests.post(
+        translate_url,
+        json={
+            'source_language': source_language,
+            'target_language': target_language,
+            'text': text
+        },
+        headers=headers
+    )
+
+    assert response.status_code == 400, f"Expected status code 400, got {response.status_code}"
+    response_data = response.json()
+    assert 'error' in response_data, "Response does not contain 'error'"
+    assert response_data['error'] == 'Invalid source language', "Error message did not match expected output"
+
+
+def test_translate_content_with_empty_text(translate_url, headers):
+    source_language = 'en'
+    target_language = 'es'
+    text = ''
+
+    response = requests.post(
+        translate_url,
+        json={
+            'source_language': source_language,
+            'target_language': target_language,
+            'text': text
+        },
+        headers=headers
+    )
+
+    assert response.status_code == 400, f"Expected status code 400, got {response.status_code}"
+    response_data = response.json()
+    assert 'error' in response_data, "Response does not contain 'error'"
+    assert response_data['error'] == 'Text cannot be empty', "Error message did not match expected output"


### PR DESCRIPTION
This pull request introduces integration testing for a translation API and updates the CI workflow to support these tests. Key changes include adding integration tests, updating the GitHub Actions workflow to set up the testing environment, and specifying dependencies for the tests.

### Integration Testing:
* Added a new integration test suite in `pytest/test_integration.py` to validate the translation API. The tests include scenarios for successful translation, invalid language input, and empty text input.

### CI Workflow Updates:
* Updated `.github/workflows/pipeline.yaml` to set up Python 3.9, install dependencies, retrieve CloudFormation outputs, and run the new integration tests. Test results are uploaded as artifacts.
* Added a new environment variable `TESTING_API_KEY` to the workflow configuration for secure API access.

### Dependency Management:
* Added a `pytest/requirements.txt` file specifying dependencies for running the integration tests, including `pytest` and `requests`.