### PR TITLE
Add AWS credentials configuration step for testing pipeline

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -216,6 +216,16 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r pytest/requirements.txt
+      - name: Assume the testing pipeline user role
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ env.PIPELINE_USER_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ env.PIPELINE_USER_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.TESTING_REGION }}
+          role-to-assume: ${{ env.TESTING_PIPELINE_EXECUTION_ROLE }}
+          role-session-name: testing-packaging
+          role-duration-seconds: 3600
+          role-skip-session-tagging: true
       - name: Get Cloudformation Outputs
         run: |
           STACK_OUTPUT=$(aws cloudformation describe-stacks \


### PR DESCRIPTION
This pull request introduces a change to the `.github/workflows/pipeline.yaml` file to enhance the CI/CD pipeline by adding a step to assume an AWS IAM role for testing purposes.

Enhancements to CI/CD pipeline:

* [`.github/workflows/pipeline.yaml`](diffhunk://#diff-a9fcf81f55b16d4db9d62258b46a56b196b1e20741c9f5fc61728a3578064b98R219-R228): Added a new step to assume the testing pipeline user role using the `aws-actions/configure-aws-credentials` GitHub Action. This includes specifying AWS credentials, region, and role details to enable secure and isolated execution of the testing pipeline.