### PR TITLE
Rename role session for testing to improve clarity and remove redunda…

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -223,7 +223,7 @@ jobs:
           aws-secret-access-key: ${{ env.PIPELINE_USER_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.TESTING_REGION }}
           role-to-assume: ${{ env.TESTING_PIPELINE_EXECUTION_ROLE }}
-          role-session-name: testing-packaging
+          role-session-name: integration-testing
           role-duration-seconds: 3600
           role-skip-session-tagging: true
       - name: Get Cloudformation Outputs
@@ -235,10 +235,6 @@ jobs:
             --output json)
           API_URL=$(echo "$STACK_OUTPUT" | jq -r '.[] | select(.OutputKey=="TranslateAPI").OutputValue')
           echo "API_URL=$API_URL" >> $GITHUB_ENV
-        env:
-          AWS_ACCESS_KEY_ID: ${{ env.PIPELINE_USER_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ env.PIPELINE_USER_SECRET_ACCESS_KEY }}
-          AWS_REGION: ${{ env.TESTING_REGION }}
       - name: Run integration tests
         run: |
           pytest --junitxml=junit/test-results.xml


### PR DESCRIPTION
…nt environment variables in integration testing step

This pull request updates the `.github/workflows/pipeline.yaml` file to refine the integration testing configuration. The most notable changes include renaming the role session and removing redundant environment variable declarations.

### Workflow Configuration Updates:

* Updated the `role-session-name` from `testing-packaging` to `integration-testing` to better reflect the purpose of the session during the integration testing phase.
* Removed redundant environment variable declarations (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_REGION`) from the integration testing step, as they are no longer needed.